### PR TITLE
Update error message for when pod metrics file is not available

### DIFF
--- a/scripts/ica-get-task-pod-metrics
+++ b/scripts/ica-get-task-pod-metrics
@@ -102,7 +102,7 @@ curated_pod_metrics_obj="$( \
 )"
 
 if [[ "$(jq --raw-output 'length' <<< "${curated_pod_metrics_obj}")" == "0" ]]; then
-  echo_stderr "Task '${task_run_id}' didn't run for long enough to capture task metrics"
+  echo_stderr "Task '${task_run_id}' didn't run for long enough to capture task metrics or the pod metrics file has been deleted"
   exit 1
 fi
 


### PR DESCRIPTION
Another reason could be the file has been archived