### PR TITLE
Updated usage for ica-get-task-pod-metrics

### DIFF
--- a/scripts/ica-get-task-pod-metrics
+++ b/scripts/ica-get-task-pod-metrics
@@ -7,7 +7,7 @@ Given a task run id, get the cpu and memory usages of that task
 
 print_help(){
   echo "
-  Usage ica-get-task-pod-metrics (--ica-task-run-id <json-file>)
+  Usage ica-get-task-pod-metrics (--ica-task-run-id <task-run-id>)
                                  [--output-format table|json]
 
   Description:


### PR DESCRIPTION
Usage should specify ica-task-run-id as value not json-file.

Fixes #51 