### PR TITLE
Check for default before declaring input as required

### DIFF
--- a/internal-functions/cwl_helpers.sh
+++ b/internal-functions/cwl_helpers.sh
@@ -46,7 +46,7 @@ is_input_required(){
 
   # Input is optional if type attribute is an array and "null" is in the type array
   jq --raw-output \
-      'if ((.type | type == "array") and (.type | any("null"))) then
+      'if ((.type | type == "array") and (.type | any("null")) and ( has(.default) | not ) ) then
           "false"
       else
           "true"


### PR DESCRIPTION
* default implies that the input is not required.

Fixes #86 