### PR TITLE
Release 1.20.0

### DIFF
--- a/autocompletion/bash/gds-presign-my-cwl-inputs.bash
+++ b/autocompletion/bash/gds-presign-my-cwl-inputs.bash
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+# Generated with perl module App::Spec v0.014
+
+_gds-presign-my-cwl-inputs() {
+
+    COMPREPLY=()
+    local IFS=$'\n'
+    local program=gds-presign-my-cwl-inputs
+    local cur prev words cword
+    _init_completion -n : || return
+    declare -a FLAGS
+    declare -a OPTIONS
+    declare -a MYWORDS
+
+    local INDEX=`expr $cword - 1`
+    MYWORDS=("${words[@]:1:$cword}")
+
+    FLAGS=('--help' 'Show command help' '-h' 'Show command help')
+    OPTIONS=('----input-json' 'Path to file
+' '----output-json' 'Path to file
+' '----in-place' 'Write presigned urls back to input jsons
+')
+    __gds-presign-my-cwl-inputs_handle_options_flags
+
+    case ${MYWORDS[$INDEX-1]} in
+      ----input-json)
+        compopt -o filenames
+        return
+      ;;
+      ----output-json)
+        compopt -o filenames
+        return
+      ;;
+      ----in-place)
+      ;;
+
+    esac
+    case $INDEX in
+
+    *)
+        __comp_current_options || return
+    ;;
+    esac
+
+}
+
+_gds-presign-my-cwl-inputs_compreply() {
+    local prefix=""
+    cur="$(printf '%q' "$cur")"
+    COMPREPLY=($(compgen -P "$prefix" -W "$*" -- "$cur"))
+    __ltrim_colon_completions "$prefix$cur"
+
+    # http://stackoverflow.com/questions/7267185/bash-autocompletion-add-description-for-possible-completions
+    if [[ ${#COMPREPLY[*]} -eq 1 ]]; then # Only one completion
+        COMPREPLY=( "${COMPREPLY[0]%% -- *}" ) # Remove ' -- ' and everything after
+        COMPREPLY=( "${COMPREPLY[0]%%+( )}" ) # Remove trailing spaces
+    fi
+}
+
+
+__gds-presign-my-cwl-inputs_dynamic_comp() {
+    local argname="$1"
+    local arg="$2"
+    local name desc cols desclength formatted
+    local comp=()
+    local max=0
+
+    while read -r line; do
+        name="$line"
+        desc="$line"
+        name="${name%$'\t'*}"
+        if [[ "${#name}" -gt "$max" ]]; then
+            max="${#name}"
+        fi
+    done <<< "$arg"
+
+    while read -r line; do
+        name="$line"
+        desc="$line"
+        name="${name%$'\t'*}"
+        desc="${desc/*$'\t'}"
+        if [[ -n "$desc" && "$desc" != "$name" ]]; then
+            # TODO portable?
+            cols=`tput cols`
+            [[ -z $cols ]] && cols=80
+            desclength=`expr $cols - 4 - $max`
+            formatted=`printf "%-*s -- %-*s" "$max" "$name" "$desclength" "$desc"`
+            comp+=("$formatted")
+        else
+            comp+=("'$name'")
+        fi
+    done <<< "$arg"
+    _gds-presign-my-cwl-inputs_compreply ${comp[@]}
+}
+
+function __gds-presign-my-cwl-inputs_handle_options() {
+    local i j
+    declare -a copy
+    local last="${MYWORDS[$INDEX]}"
+    local max=`expr ${#MYWORDS[@]} - 1`
+    for ((i=0; i<$max; i++))
+    do
+        local word="${MYWORDS[$i]}"
+        local found=
+        for ((j=0; j<${#OPTIONS[@]}; j+=2))
+        do
+            local option="${OPTIONS[$j]}"
+            if [[ "$word" == "$option" ]]; then
+                found=1
+                i=`expr $i + 1`
+                break
+            fi
+        done
+        if [[ -n $found && $i -lt $max ]]; then
+            INDEX=`expr $INDEX - 2`
+        else
+            copy+=("$word")
+        fi
+    done
+    MYWORDS=("${copy[@]}" "$last")
+}
+
+function __gds-presign-my-cwl-inputs_handle_flags() {
+    local i j
+    declare -a copy
+    local last="${MYWORDS[$INDEX]}"
+    local max=`expr ${#MYWORDS[@]} - 1`
+    for ((i=0; i<$max; i++))
+    do
+        local word="${MYWORDS[$i]}"
+        local found=
+        for ((j=0; j<${#FLAGS[@]}; j+=2))
+        do
+            local flag="${FLAGS[$j]}"
+            if [[ "$word" == "$flag" ]]; then
+                found=1
+                break
+            fi
+        done
+        if [[ -n $found ]]; then
+            INDEX=`expr $INDEX - 1`
+        else
+            copy+=("$word")
+        fi
+    done
+    MYWORDS=("${copy[@]}" "$last")
+}
+
+__gds-presign-my-cwl-inputs_handle_options_flags() {
+    __gds-presign-my-cwl-inputs_handle_options
+    __gds-presign-my-cwl-inputs_handle_flags
+}
+
+__comp_current_options() {
+    local always="$1"
+    if [[ -n $always || ${MYWORDS[$INDEX]} =~ ^- ]]; then
+
+      local options_spec=''
+      local j=
+
+      for ((j=0; j<${#FLAGS[@]}; j+=2))
+      do
+          local name="${FLAGS[$j]}"
+          local desc="${FLAGS[$j+1]}"
+          options_spec+="$name"$'\t'"$desc"$'\n'
+      done
+
+      for ((j=0; j<${#OPTIONS[@]}; j+=2))
+      do
+          local name="${OPTIONS[$j]}"
+          local desc="${OPTIONS[$j+1]}"
+          options_spec+="$name"$'\t'"$desc"$'\n'
+      done
+      __gds-presign-my-cwl-inputs_dynamic_comp 'options' "$options_spec"
+
+      return 1
+    else
+      return 0
+    fi
+}
+
+
+complete -o default -F _gds-presign-my-cwl-inputs gds-presign-my-cwl-inputs
+

--- a/autocompletion/specs/gds-presign-my-cwl-inputs.yaml
+++ b/autocompletion/specs/gds-presign-my-cwl-inputs.yaml
@@ -1,0 +1,17 @@
+---
+name: gds-presign-my-cwl-inputs
+
+title: Presign cwl inputs to use in another project
+
+options:
+  - name: --input-json
+    summary: |
+      Path to file
+    type: file
+  - name: --output-json
+    summary: |
+      Path to file
+    type: file
+  - name: --in-place
+    summary: |
+      Write presigned urls back to input jsons

--- a/autocompletion/zsh/_gds-presign-my-cwl-inputs
+++ b/autocompletion/zsh/_gds-presign-my-cwl-inputs
@@ -1,0 +1,48 @@
+#compdef gds-presign-my-cwl-inputs
+
+# Generated with perl module App::Spec v0.014
+
+_gds-presign-my-cwl-inputs() {
+    local program=gds-presign-my-cwl-inputs
+    typeset -A opt_args
+    local curcontext="$curcontext" state line context
+
+
+        # ---- Command: 
+        _arguments -s  \
+            '----input-json[Path to file
+]:--input-json:_files' \
+            '----output-json[Path to file
+]:--output-json:_files' \
+            '----in-place[Write presigned urls back to input jsons
+]:--in-place' \
+            '--help[Show command help]' \
+            '-h[Show command help]' \
+            && ret=0
+
+
+
+}
+
+
+__gds-presign-my-cwl-inputs_dynamic_comp() {
+    local argname="$1"
+    local arg="$2"
+    local comp="arg:$argname:(("
+    local line
+    while read -r line; do
+        local name="$line"
+        local desc="$line"
+        name="${name%$'\t'*}"
+        desc="${desc/*$'\t'}"
+        comp="$comp$name"
+        if [[ -n "$desc" && "$name" != "$desc" ]]; then
+            comp="$comp\\:"'"'"$desc"'"'
+        fi
+        comp="$comp "
+    done <<< "$arg"
+
+    comp="$comp))"
+    _alternative "$comp"
+}
+

--- a/internal-functions/presign_helpers.sh
+++ b/internal-functions/presign_helpers.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+flatten_inputs_from_launch_json(){
+  : '
+  Returns a flatten list of inputs
+  '
+  local launch_json_str="$1"
+  local inputs
+
+  inputs="$( \
+    jq --raw-output \
+      '
+        .input
+      ' <<< "${launch_json_str}"
+  )"
+
+  # Check if inputs are null
+  if [[ -z "${inputs}" || "${inputs}" == "null" ]]; then
+    echo_stderr "Could not find any inputs"
+    return 1
+  fi
+
+  # Flatten input json into .dot format
+  flatten_inputs "${inputs}"
+}
+
+
+presign_flatten_inputs(){
+  : '
+  Find files inputs, returns key val pairing of gds path and presigned url
+  '
+
+  flattened_inputs="$1"
+
+  # Iterate through key val pairs
+  # Like tumor_fastq_list_rows.0.read_1.location=gds://...
+  while read -r input_key_val_pair; do
+     # Split into keys and values
+     input_key="$(cut -d'=' -f1 <<< "${input_key_val_pair}")"
+     # Strip input key to just get first element umccrise_tsv_rows.0.sv_vcf.path to umccrise_tsv_rows
+     input_key_lstripped="$(strip_first_period "${input_key}")"
+     # Stripped input key umccrise_tsv_rows.0.sv_vcf.path to just umccrise_tsv_rows.0.sv_vcf
+     input_key_rstripped="$(strip_last_period "${input_key}")"
+     input_value="$(cut -d'=' -f2 <<< "${input_key_val_pair}")"
+
+     class_type="$(get_class_type "${input_key_rstripped}" "${flattened_inputs}")"
+     # Check if the input-key ends in .path or .location
+     if [[ "${input_key}" =~ .*\.path || "${input_key}" =~ .*\.location ]]; then
+        # Get class type
+        class_type="$(get_class_type "${input_key_rstripped}" "${flattened_inputs}")"
+        if [[ "${class_type}" == "gds_file" && "${input_value}" =~ ^gds://.* ]]; then
+          echo_stderr "Input '${input_key}' is a gds file at '${input_value}' presigning"
+          volume_name="$(get_volume_from_gds_path "${input_value}")"
+          file_path="$(get_file_path_from_gds_path "${input_value}")"
+          input_file_id="$( \
+            get_file_id \
+              "${volume_name}" \
+              "${file_path}" \
+              "${ICA_BASE_URL}" \
+              "${ICA_ACCESS_TOKEN}" \
+          )"
+          presigned_url="$( \
+            get_presigned_url_from_file_id \
+              "${input_file_id}" \
+              "${ICA_BASE_URL}" \
+              "${ICA_ACCESS_TOKEN}" \
+          )"
+          jq --null-input --raw-output \
+            --arg "gds_path" "${input_value}" \
+            --arg "presigned_url" "${presigned_url}" \
+            '
+              {
+                "key": $gds_path,
+                "value": $presigned_url
+              }
+            '
+        fi
+     fi
+  done <<< "${flattened_inputs}" | \
+  jq --raw-output --compact-output --slurp \
+    '
+     .[]
+    '
+}
+

--- a/scripts/gds-presign-my-cwl-inputs
+++ b/scripts/gds-presign-my-cwl-inputs
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+#!/usr/bin/env bash
+
+: '
+Iterate through file inputs and convert gds locations to presigned urls
+'
+
+
+print_help(){
+  echo "
+  Usage gds-presign-my-cwl-inputs (--input-json <json-file>)
+                                  [--output-json <output-json>]
+                                  [--in-place]
+
+  Description:
+    Looks through the workflow input object and presigns any file locations.
+    This script does NOT support directories.
+
+  Options:
+    -i / --input-json: The launch version request json file you wish to analyse. Use '-' for stdin
+    -o / --output-json: The output file you would like to write to. Use '-' for stdout. Not compatible with --in-place parameter.
+    --in-place: Write 'in-place', not compatible with the --output-json parameter
+
+  Requirements:
+    * curl
+    * jq
+    * python3
+    * sed (gnutls)
+
+  Environment variables:
+    * ICA_ACCESS_TOKEN
+    * ICA_BASE_URL
+  "
+}
+
+######
+# ARGS
+######
+
+# Get args from the command line
+input_json=""
+output_json=""
+in_place="false"
+
+# Get args from command line
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -i | --input-json)
+      input_json="$2"
+      shift 1
+      ;;
+    -o | --output-json)
+      output_json="$2"
+      shift 1
+      ;;
+    --in-place)
+      in_place="true"
+      ;;
+    -h | --help)
+      print_help
+      exit 0
+      ;;
+  esac
+  shift 1
+done
+
+###########ICA-ICA-LAZY SETUP ########################################
+
+if [[ -z "${ICA_ICA_LAZY_HOME-}" ]]; then
+  echo "Error - please ensure env var 'ICA_ICA_LAZY_HOME' is set" 1>&2
+  exit 1
+fi
+
+if [[ -d "${ICA_ICA_LAZY_HOME}/internal-functions" ]]; then
+  for f in "${ICA_ICA_LAZY_HOME}/internal-functions/"*".sh"; do
+      # shellcheck source=../internal-functions/*.sh
+      source "$f"
+  done
+fi
+
+##########END ICA-ICA-LAZY SETUP ####################################
+
+
+# Check ICA_BASE_URL env var is set
+if [[ -z "${ICA_BASE_URL-}" ]]; then
+  echo_stderr "Please set ICA_BASE_URL"
+  print_help
+  exit 1
+fi
+
+# Check we're in a project context
+if [[ -z "${ICA_ACCESS_TOKEN-}" ]]; then
+  echo_stderr "Please specify ICA_ACCESS_TOKEN"
+  print_help
+  exit 1
+fi
+
+# Make sure input_json is defined and is a file
+if [[ -z "${input_json}" ]]; then
+  echo_stderr "Please specify --input-json parameter"
+  print_help
+  exit 1
+elif [[ "${input_json}" == "-" ]]; then
+  :
+elif [[ ! -f "${input_json}" ]]; then
+  echo_stderr "--input-json specified as ${input_json} but could not find file."
+  print_help
+  exit 1
+fi
+
+# Check output_json exists (or --in-place is set)
+if [[ "${in_place}" == "true" ]]; then
+  : # Pass
+elif [[ -z "${output_json}" ]]; then
+  echo_stderr "Please specify --output-json parameter"
+  print_help
+  exit 1
+elif [[ "${output_json}" == "-" ]]; then
+  :  # Pass
+elif [[ ! -d "$(dirname "${output_json}")" ]]; then
+  echo_stderr "Parent directory of '${output_json}' does not exist. Please create and try again"
+  exit 1
+fi
+
+# Check not in-place and --input-json = '-'
+if [[ "${in_place}" == "true" && "${input_json}" == "-" ]]; then
+  echo_stderr "Cannot set --in-place when using stdin"
+# Check not in-place and --output-json
+elif [[ "${in_place}" == "true" && -n "${output_json}" ]]; then
+  echo_stderr "Cannot set --in-place when using --output-json"
+fi
+
+# Check token expiry
+check_token_expiry "${ICA_ACCESS_TOKEN}"
+
+# Check json integrity
+if [[ "${input_json}" == "-" ]]; then
+  if ! input_json_str="$(
+    jq --raw-output < /dev/stdin
+  )"; then
+    echo_stderr "Could not confirm stdin '${input_json}' was valid json"
+    return 1
+  fi
+elif ! jq type "${input_json}" >/dev/null 2>&1; then
+  echo_stderr "Could not confirm input json '${input_json}' was a valid json"
+  print_help
+  exit 1
+else
+  input_json_str="$(jq --raw-output < "${input_json}")"
+fi
+
+# Flatten inputs
+flattened_inputs="$(flatten_inputs_from_launch_json "${input_json_str}")"
+
+# Presign flattened inputs
+readarray -t presigned_json_array <<< "$(presign_flatten_inputs "${flattened_inputs}")"
+
+# Edit input json
+edited_json_str="${input_json_str}"
+
+# Iterate through presigned urls
+# Update with string matching
+for row in "${presigned_json_array[@]}"; do
+  key="$(jq --raw-output '.key' <<< "${row}")"
+  value="$(jq --raw-output '.value' <<< "${row}")"
+  edited_json_str="${edited_json_str//${key}/${value}}"
+done
+
+# Copy outputs to output json / stdout / or back to input json
+if [[ "${output_json}" == "-" ]]; then
+  jq --raw-output <<< "${edited_json_str}"
+elif [[ "${in_place}" == "true" ]]; then
+  echo_stderr "Writing presigned urls in-place back to '${input_json}'"
+  jq --raw-output <<< "${edited_json_str}" > "${input_json}"
+else
+  jq --raw-output <<< "${edited_json_str}" > "${output_json}"
+fi
+


### PR DESCRIPTION
New feature 

gds-presign-my-cwl-inputs, 

For running workflows with files from another project.  

```
gds-presign-my-cwl-inputs --help

  Usage gds-presign-my-cwl-inputs (--input-json <json-file>)
                                  [--output-json <output-json>]
                                  [--in-place]

  Description:
    Looks through the workflow input object and presigns any file locations.
    This script does NOT support directories.

  Options:
    -i / --input-json: The launch version request json file you wish to analyse. Use '-' for stdin
    -o / --output-json: The output file you would like to write to. Use '-' for stdout. Not compatible with --in-place parameter.
    --in-place: Write 'in-place', not compatible with the --output-json parameter

  Requirements:
    * curl
    * jq
    * python3
    * sed (gnutls)

  Environment variables:
    * ICA_ACCESS_TOKEN
    * ICA_BASE_URL
```