### PR TITLE
Use rclone to copy files from gds to aws

### DIFF
--- a/internal-functions/v2-migration-helpers.sh
+++ b/internal-functions/v2-migration-helpers.sh
@@ -12,9 +12,12 @@ icav2_get_project_id_from_project_name() {
   project_name="$1"
   icav2_base_url="$2"
   icav2_access_token="$3"
+  local page_size
+
+  page_size=1000
 
   curl --silent --fail --location --request "GET" \
-    --url "${icav2_base_url}/api/projects" \
+    --url "${icav2_base_url}/api/projects?pageSize=${page_size}" \
     --header 'Accept: application/vnd.illumina.v3+json' \
     --header "Authorization: Bearer ${icav2_access_token}" | \
   jq --raw-output \
@@ -227,13 +230,6 @@ get_v2_folder_aws_credentials(){
   jq --raw-output \
     '.awsTempCredentials'
 }
-
-
-#!/usr/bin/env bash
-
-: '
-
-'
 
 get_aws_access_creds_from_folder_id() {
   : '

--- a/scripts/gds-migrate-to-aws
+++ b/scripts/gds-migrate-to-aws
@@ -31,17 +31,18 @@ TEMPLATE_NAME="gds-migrate-to-aws-task-run.json"
 # Help function
 print_help(){
   echo "
-        Usage: gds-migrate-to-aws (--gds-path gds://volume-name/path-to-src-folder/) (--s3-path)
-                                  [--stream]
+        Usage: gds-migrate-to-aws (--gds-path gds://volume-name/path-to-src-folder/)
+                                  (--s3-path s3://bucket-name/path-to-dest-folder/)
+                                  (--log-path gds://volume-name/path-to-logs-folder/)
+                                  [...additional_rclone_args]
 
         Description:
-          Copy data from one project folder to a folder in another project context
+          Sync data from gds to AWS using rclone
 
         Options:
-            --gds-path:          path to gds source directory
-            --s3-path:           path to gds dest directory
-            --stream:            Use stream mode for inputs, download is default
-            ...                  Additional arguments are parsed to s3-sync
+            --gds-path:          Path to gds source directory
+            --s3-path:           Path to s3 destination directory
+            ...                  Additional arguments are parsed to rclone
 
         Requirements:
           * aws
@@ -57,7 +58,7 @@ print_help(){
 
         Extras:
             *  You can also use any of the aws s3 sync parameters to add to the command list, for example
-               gds-migrate-to-aws --gds-path gds://volume-name/path-to-folder/ --s3-path s3://temp-bucket/folder/ --exclude='*' --include='*.fastq.gz'
+               gds-migrate-to-aws --gds-path gds://volume-name/path-to-folder/ --s3-path s3://bucket-name/path-to-folder/ --exclude='*' --include='*.fastq.gz'
                will download only fastq files from that gds folder.
 
                Unlike rsync, trailing slashes on the --gds-path and --s3-path do not matter. One can assume that
@@ -83,8 +84,8 @@ print_help(){
 src_gds_path=""
 src_project=""
 dest_s3_path=""
-aws_s3_sync_args_array=""
-input_mode="download"
+log_path=""
+rclone_copy_args_array=""
 template_path="${ICA_ICA_LAZY_HOME-}/templates/${TEMPLATE_NAME}"
 
 # Get args from command line
@@ -98,8 +99,9 @@ while [ $# -gt 0 ]; do
       dest_s3_path="$2"
       shift 1
       ;;
-    --stream)
-      input_mode="stream"
+    --log-path)
+      log_path="$2"
+      shift 1
       ;;
     -h | --help)
       print_help
@@ -107,7 +109,7 @@ while [ $# -gt 0 ]; do
       ;;
     --*)
       # Let's add in the parameter arg
-      aws_s3_sync_args_array=("${aws_s3_sync_args_array[@]}" "$1")
+      rclone_copy_args_array=("${rclone_copy_args_array[@]}" "$1")
       # First check if $2 is of any length
       if [[ -n "${2-}" ]]; then
         # Check if the parameter takes a value
@@ -117,7 +119,7 @@ while [ $# -gt 0 ]; do
             :
             ;;
           *)
-            aws_s3_sync_args_array=("${aws_s3_sync_args_array[@]}" "$2")
+            rclone_copy_args_array=("${rclone_copy_args_array[@]}" "$2")
             shift 1
             ;;
         esac
@@ -152,6 +154,11 @@ if [[ -z "${dest_s3_path}" ]]; then
   echo_stderr "Please make sure --s3-path parameter is set"
   exit 1
 fi
+if [[ -z "${log_path}" ]]; then
+  echo_stderr "Please make sure --log-path parameter is set"
+  exit 1
+fi
+
 
 # Start
 if [[ -z "${ICA_BASE_URL-}" ]]; then
@@ -173,98 +180,107 @@ if ! check_path_is_folder "${src_volume_name}" "${src_folder_path}" "${ICA_BASE_
   exit 1
 fi
 
-# Get file list object as a gds file list in the source
-echo_stderr "Collecting presigned urls from source path"
-file_list_obj="$(get_gds_file_list_as_digestible "${src_volume_name}" "${src_folder_path}" "true" "${ICA_BASE_URL}" "${ICA_ACCESS_TOKEN}")"
+# Get the folder in gds
+src_folder_id="$(get_folder_id "${src_volume_name}" "${src_folder_path}" "${ICA_BASE_URL}" "${ICA_ACCESS_TOKEN}")"
 
-# Reshape json and write out
-temp_manifest_path="$("$(get_mktemp_binary)" -t "manifest.XXX.json")"
-jq --raw-output \
-  '. | select(.file_size != 0) | {url: .presigned_url, size: .file_size, path: .output_path}' <<< "${file_list_obj}" | \
-jq --raw-output --slurp > "${temp_manifest_path}"
+# Get access credentials from the source project
+src_aws_credentials="$(get_aws_access_creds_from_folder_id "${src_folder_id}" "${ICA_BASE_URL}" "${ICA_ACCESS_TOKEN}")"
 
-# Get the dest stuff volume name / folder path
-dest_volume_name="$(get_volume_from_gds_path "${dest_s3_path}")"
-dest_folder_path="$(get_folder_path_from_gds_path "${dest_s3_path}")"
-dest_folder_parent="$(dirname "${dest_folder_path}")"
-log_path="${dest_folder_parent}/logs"
+# Creds to be exported
+src_aws_access_key_id="$(get_access_key_id_from_credentials "${src_aws_credentials}")"
+src_aws_secret_access_key="$(get_secret_access_key_from_credentials "${src_aws_credentials}")"
+src_aws_session_token="$(get_session_token_from_credentials "${src_aws_credentials}")"
+src_aws_region="$(get_region_from_credentials "${src_aws_credentials}")"
 
-# Upload manifest
-s3_manifest_path="s3://${dest_volume_name}${dest_folder_parent}/$(basename "${temp_manifest_path}")"
-echo_stderr "Uploading file ${temp_manifest_path} to ${s3_manifest_path}"
-echo "Uploading manifest file to s3"
-aws s3 cp "${temp_manifest_path}" "${s3_manifest_path}"
-manifest_presigned_url="$( \
-  aws s3 presign "${s3_manifest_path}" \
-)"
+# Components of positional parameter 1
+src_aws_bucket_name="$(get_bucket_name_from_credentials "${src_aws_credentials}")"
+src_aws_key_prefix="$(get_key_prefix_from_credentials "${src_aws_credentials}")"
 
-# Create log directory
-aws s3api put-object --bucket "${dest_volume_name}" --key "${log_path#/}/" --content-length 0
+# Get the dest stuff
+if [[ -z "${AWS_REGION-}" || "${AWS_DEFAULT_REGION-}" ]]; then
+  echo_stderr "Error: AWS_REGION or AWS_DEFAULT_REGION must be set"
+  exit 1
+fi
+if [[ -n "${AWS_REGION-}" ]]; then
+  dest_aws_region="${AWS_REGION}"
+else
+  dest_aws_region="${AWS_DEFAULT_REGION}"
+fi
 
-# Create temp file with template
-temp_test_migration_path="$("$(get_mktemp_binary)" -t "tes-migrate.XXX.json")"
-cp "${template_path}" "${temp_test_migration_path}"
-
+# These commands don't require 'gds://' at the front so usable for s3 too
+dest_aws_bucket_name="$(get_volume_from_gds_path "${dest_s3_path}")"
+dest_aws_key_prefix="$(get_folder_path_from_gds_path "${dest_s3_path}")"
 
 if [[ -n "${AWS_ACCESS_KEY_ID-}" && -n "${AWS_SECRET_ACCESS_KEY}" && -n "${AWS_SESSION_TOKEN}" ]]; then
   : '
   Were all good here!
   '
-  aws_access_key_id="${AWS_ACCESS_KEY_ID}"
-  aws_secret_access_key="${AWS_SECRET_ACCESS_KEY}"
-  aws_session_token="${AWS_SESSION_TOKEN}"
+  dest_aws_access_key_id="${AWS_ACCESS_KEY_ID}"
+  dest_aws_secret_access_key="${AWS_SECRET_ACCESS_KEY}"
+  dest_aws_session_token="${AWS_SESSION_TOKEN}"
 elif type aws-sso-creds 1>/dev/null 2>&1; then
   if [[ -z "${AWS_PROFILE-}" && -z "${AWS_DEFAULT_PROFILE-}" ]]; then
     echo_stderr "Cannot use aws-sso-creds without knowing the aws profile. Please set either AWS_PROFILE or AWS_DEFAULT_PROFILE environment vars and try again"
   fi
   # Crete aws access key id
   aws_sso_creds_str="$( \
-    aws-sso-creds export | \
-    "$(get_sed_binary)" 's/export //' \
+    aws-sso-creds get | \
+    "$(get_sed_binary)" -E 's/\s+/ /' \
   )"
 
-  aws_access_key_id="$(
-    grep "AWS_ACCESS_KEY_ID=" <<< "${aws_sso_creds_str}" | "$(get_sed_binary)" 's/AWS_ACCESS_KEY_ID=//'
+  dest_aws_access_key_id="$(
+    grep "AWS_ACCESS_KEY_ID" <<< "${aws_sso_creds_str}" | cut -d' ' -f2
   )"
 
-  aws_secret_access_key="$(
-    grep "AWS_SECRET_ACCESS_KEY=" <<< "${aws_sso_creds_str}" | "$(get_sed_binary)" 's/AWS_SECRET_ACCESS_KEY=//'
+  dest_aws_secret_access_key="$(
+    grep "AWS_SECRET_ACCESS_KEY" <<< "${aws_sso_creds_str}" | cut -d' ' -f2
   )"
 
-  aws_session_token="$(
-    grep "AWS_SESSION_TOKEN=" <<< "${aws_sso_creds_str}" | "$(get_sed_binary)" 's/AWS_SESSION_TOKEN=//'
+  dest_aws_session_token="$(
+    grep "AWS_SESSION_TOKEN" <<< "${aws_sso_creds_str}" | cut -d' ' -f2
   )"
 else
   echo_stderr "No way to get AWS credentials, please install aws-sso-creds or set the following environment vars"
   echo_stderr "AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN"
 fi
 
+# Get the log stuff
+log_volume_name="$(get_volume_from_gds_path "${log_path}")"
+log_folder_path="$(get_folder_path_from_gds_path "${log_path}")"
+
+# Create temp file with template
+temp_tes_migration_path="$("$(get_mktemp_binary)" -t "tes-migrate.XXX.json")"
+cp "${template_path}" "${temp_tes_migration_path}"
 
 # Update template TES json
 echo_stderr "Populating TES task template"
-"$(get_sed_binary)" -i "s#__GDS_MANIFEST_JSON_URL__#${manifest_presigned_url//&/\\&}#" "${temp_test_migration_path}"
-"$(get_sed_binary)" -i "s%__AWS_ACCESS_KEY_ID__%${aws_access_key_id}%" "${temp_test_migration_path}"
-"$(get_sed_binary)" -i "s%__AWS_SECRET_ACCESS_KEY__%${aws_secret_access_key}%" "${temp_test_migration_path}"
-"$(get_sed_binary)" -i "s%__AWS_SESSION_TOKEN__%${aws_session_token}%" "${temp_test_migration_path}"
-"$(get_sed_binary)" -i "s%__AWS_S3_LOGS_PATH__%s3://${dest_volume_name}${log_path}%" "${temp_test_migration_path}"
+"$(get_sed_binary)" -i "s%__SRC_AWS_REGION__%${src_aws_region}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__SRC_AWS_ACCESS_KEY_ID__%${src_aws_access_key_id}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__SRC_AWS_SECRET_ACCESS_KEY__%${src_aws_secret_access_key}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__SRC_AWS_SESSION_TOKEN__%${src_aws_session_token}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__SRC_AWS_BUCKET_NAME__%${src_aws_bucket_name}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__SRC_AWS_KEY_PREFIX__%${src_aws_key_prefix}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__DEST_AWS_REGION__%${dest_aws_region}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__DEST_AWS_ACCESS_KEY_ID__%${dest_aws_access_key_id}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__DEST_AWS_SECRET_ACCESS_KEY__%${dest_aws_secret_access_key}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__DEST_AWS_SESSION_TOKEN__%${dest_aws_session_token}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__DEST_AWS_BUCKET_NAME__%${dest_aws_bucket_name}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__DEST_AWS_KEY_PREFIX__%${dest_aws_key_prefix}%" "${temp_tes_migration_path}"
+"$(get_sed_binary)" -i "s%__GDS_SYSTEM_FILES_PATH__%gds://${log_volume_name}${log_folder_path%/}%" "${temp_tes_migration_path}"
 
-# Add in rsync args
-for s3_sync_arg in "${aws_s3_sync_args_array[@]}"; do
-  if [[ -n "${s3_sync_arg}" ]]; then
-    s3_sync_str+="  \\\\"'"'"${s3_sync_arg}\\\\"'"'
+# Add in rclone args
+for rclone_copy_arg in "${rclone_copy_args_array[@]}"; do
+  if [[ -n "${rclone_copy_arg}" ]]; then
+    rclone_copy_str+=" \\\\"'"'"${rclone_copy_arg}\\\\"'"'
   fi
 done
 
-if [[ -v s3_sync_str ]]; then
-  "$(get_sed_binary)" -i "s%__ADDITIONAL_S3_SYNC_ARGS__%${s3_sync_str}%" "${temp_test_migration_path}"
+if [[ -v rclone_copy_str ]]; then
+  "$(get_sed_binary)" -i "s%__ADDITIONAL_RCLONE_SYNC_ARGS__%${rclone_copy_str}%" "${temp_tes_migration_path}"
 else
-  "$(get_sed_binary)" -i "s%__ADDITIONAL_S3_SYNC_ARGS__%%" "${temp_test_migration_path}"
+  "$(get_sed_binary)" -i "s%__ADDITIONAL_RCLONE_SYNC_ARGS__%%" "${temp_tes_migration_path}"
 fi
 
-"$(get_sed_binary)" -i "s%__AWS_S3_DEST_PATH__%${dest_s3_path}%" "${temp_test_migration_path}"
-
-# Determine if stream or download
-"$(get_sed_binary)" -i "s%__STREAM_OR_DOWNLOAD__%${input_mode}%" "${temp_test_migration_path}"
 
 # Launch the tes task
 echo_stderr "Launching TES task"
@@ -278,7 +294,7 @@ tes_task_id="$( \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/*+json' \
     --header "Authorization: Bearer ${ICA_ACCESS_TOKEN}" \
-    --data "@${temp_test_migration_path}" \
+    --data "@${temp_tes_migration_path}" \
     --url "${ICA_BASE_URL}/v1/tasks/runs" |
     jq --raw-output \
       '.id' \
@@ -286,4 +302,4 @@ tes_task_id="$( \
 
 echo_stderr "Launching data transfer with task run ${tes_task_id}"
 
-# rm "${temp_test_migration_path}"
+rm "${temp_tes_migration_path}"

--- a/scripts/ica-ega-uploader
+++ b/scripts/ica-ega-uploader
@@ -208,4 +208,4 @@ tes_aspera_task_id="$( \
 
 echo_stderr "Launched ${tes_aspera_task_id}"
 
-rm "${temp_aspera_task}"
+#rm "${temp_aspera_task}"

--- a/templates/gds-migrate-to-aws-task-run.json
+++ b/templates/gds-migrate-to-aws-task-run.json
@@ -2,41 +2,34 @@
   "name": "gds-migrate-to-aws",
   "execution": {
     "image": {
-      "name": "ghcr.io/umccr/aws-cli-with-extras",
-      "tag": "2.9.19"
+      "name": "ghcr.io/umccr/rclone",
+      "tag": "1.66.0"
     },
     "command": "bash",
     "args": [
       "-c",
-      "AWS_ACCESS_KEY_ID=\"${SECURE_AWS_ACCESS_KEY_ID}\" AWS_SECRET_ACCESS_KEY=\"${SECURE_AWS_SECRET_ACCESS_KEY}\" AWS_SESSION_TOKEN=\"${SECURE_AWS_SESSION_TOKEN}\" aws s3 sync /mount/mount/media/inputs/ \"__AWS_S3_DEST_PATH__\"__ADDITIONAL_S3_SYNC_ARGS__"
+      "rclone-config-maker --src-access-key-id \"${SECURE_SRC_AWS_ACCESS_KEY_ID}\" --src-secret-access-key \"${SECURE_SRC_AWS_SECRET_ACCESS_KEY}\" --src-session-token \"${SECURE_SRC_AWS_SESSION_TOKEN}\" --src-region \"${SRC_AWS_REGION}\" --dest-access-key-id \"${SECURE_DEST_AWS_ACCESS_KEY_ID}\" --dest-secret-access-key \"${SECURE_DEST_AWS_SECRET_ACCESS_KEY}\" --dest-session-token \"${SECURE_DEST_AWS_SESSION_TOKEN}\" --dest-region \"${DEST_AWS_REGION}\" --config-output-path \"${RCLONE_CONFIG}\"; rclone sync__ADDITIONAL_RCLONE_SYNC_ARGS__ \"src:__SRC_AWS_BUCKET_NAME__/__SRC_AWS_KEY_PREFIX__\" \"dest:__DEST_AWS_BUCKET_NAME____DEST_AWS_KEY_PREFIX__\""
     ],
-    "inputs": [
-      {
-        "type": "manifest",
-        "mode": "__STREAM_OR_DOWNLOAD__",
-        "url": "__GDS_MANIFEST_JSON_URL__",
-        "path": "/mount/mount/media/inputs/"
-      }
-    ],
+    "inputs": [],
     "outputs": [],
     "systemFiles": {
-      "url": "__AWS_S3_LOGS_PATH__",
-      "storageProvider": "aws",
-      "credentials": {
-        "AWS_ACCESS_KEY_ID": "__AWS_ACCESS_KEY_ID__",
-        "AWS_SECRET_ACCESS_KEY": "__AWS_SECRET_ACCESS_KEY__",
-        "AWS_SESSION_TOKEN": "__AWS_SESSION_TOKEN__"
-      }
+      "url": "__GDS_SYSTEM_FILES_PATH__"
     },
     "environment": {
       "variables": {
-        "SECURE_AWS_ACCESS_KEY_ID": "__AWS_ACCESS_KEY_ID__",
-        "SECURE_AWS_SECRET_ACCESS_KEY": "__AWS_SECRET_ACCESS_KEY__",
-        "SECURE_AWS_SESSION_TOKEN": "__AWS_SESSION_TOKEN__"
+        "SECURE_SRC_AWS_ACCESS_KEY_ID": "__SRC_AWS_ACCESS_KEY_ID__",
+        "SECURE_SRC_AWS_SECRET_ACCESS_KEY": "__SRC_AWS_SECRET_ACCESS_KEY__",
+        "SECURE_SRC_AWS_SESSION_TOKEN": "__SRC_AWS_SESSION_TOKEN__",
+        "SRC_AWS_REGION": "__SRC_AWS_REGION__",
+        "SECURE_DEST_AWS_ACCESS_KEY_ID": "__DEST_AWS_ACCESS_KEY_ID__",
+        "SECURE_DEST_AWS_SECRET_ACCESS_KEY": "__DEST_AWS_SECRET_ACCESS_KEY__",
+        "SECURE_DEST_AWS_SESSION_TOKEN": "__DEST_AWS_SESSION_TOKEN__",
+        "DEST_AWS_REGION": "__DEST_AWS_REGION__",
+        "RCLONE_CONFIG": "/tmp/rclone-config-path.cfg"
       },
       "resources": {
         "type": "standardhicpu",
-        "size": "small"
+        "size": "medium"
       }
     },
     "retryLimit": 0


### PR DESCRIPTION
## Feature

Use rclone with python script to generate rclone conf and copy files from gds to aws

Testing with `trn.e86ebcb556194202b439603520ea86c7` which is transferring 254 files to umccr-temp-dev with a total of 295 Gb.  

It's taking a while, but the directory it's transferring is actually only really two files comprising one 226 Gb file and one 80 Gb file, the other 252 files comprise a total of 86 Mb.  So this might not showcase the best use of rclone.  


## Miscell

Also update page size when copying files from gds to icav2.  

